### PR TITLE
Update json2args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM python:3.10
 
 # install the toolbox runner tools
-RUN pip install toolbox-runner
+RUN pip install json2args
 
 
 # Do anything you need to install tool dependencies here

--- a/src/run.py
+++ b/src/run.py
@@ -1,5 +1,6 @@
 import os
 from datetime import datetime as dt
+from pprint import pprint
 
 from json2args import get_parameter
 
@@ -12,10 +13,11 @@ toolname = os.environ.get('TOOL_RUN', 'foobar').lower()
 # switch the tool
 if toolname == 'foobar':
     # RUN the tool here and create the output in /out
-    with open('/out/STDOUT.log', 'w') as f:
-        f.write('This toolbox does not include any tool. Did you run the template?\n')
+    print('This toolbox does not include any tool. Did you run the template?\n')
+    
+    # write parameters to STDOUT.log
+    pprint(kwargs)
 
 # In any other case, it was not clear which tool to run
 else:
-    with open('/out/error.log', 'w') as f:
-        f.write(f"[{dt.now().isocalendar()}] Either no TOOL_RUN environment variable available, or '{toolname}' is not valid.\n")
+    raise AttributeError(f"[{dt.now().isocalendar()}] Either no TOOL_RUN environment variable available, or '{toolname}' is not valid.\n")

--- a/src/run.py
+++ b/src/run.py
@@ -1,10 +1,10 @@
 import os
 from datetime import datetime as dt
 
-from toolbox_runner.parameter import parse_parameter
+from json2args import get_parameter
 
 # parse parameters
-kwargs = parse_parameter()
+kwargs = get_parameter()
 
 # check if a toolname was set in env
 toolname = os.environ.get('TOOL_RUN', 'foobar').lower()


### PR DESCRIPTION
Removing `toolbox-runner` as a dependency. Now the dedicated package `json2args` can be used, which is purposed to only parse parameters inside `tool_` docker container.

@AlexDo1, can you build this container locally (from this branch) and confirm, that parameters are still parsed correctly?