### PR TITLE
remove deprecated version attribute

### DIFF
--- a/src/tool.yml
+++ b/src/tool.yml
@@ -2,7 +2,6 @@ tools:
   foobar:
     title: Foo Bar
     description: A dummy tool to exemplify the YAML file
-    version: 0.1
     parameters:
       foo_int: 
         type: integer


### PR DESCRIPTION
This little PR removes the long deprecated version attribute from the tool.yml

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove the deprecated `version` field from `src/tool.yml` under `tools.foobar`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e502c099832ce77dff6182fb50757ee6fb6ef616. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated tool configuration by removing the version field.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->