### PR TITLE
Integrate gotap binary and use command field

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,13 @@ RUN pip install "json2args[data]>=0.6.2"
 # with less dependencies
 # RUN pip install json2args>=0.6.2
 
+# Build spec binary from source
+RUN apt-get update && apt-get install -y golang-go git && \
+    git clone https://github.com/hydrocode-de/gotap.git /tmp/gotap && \
+    cd /tmp/gotap && go build -o /usr/local/bin/spec ./main.go && \
+    rm -rf /tmp/gotap && \
+    apt-get remove -y golang-go git && apt-get autoremove -y && apt-get clean
+
 # Do anything you need to install tool dependencies here
 RUN echo "Replace this line with a tool"
 
@@ -23,4 +30,4 @@ COPY ./src /src
 COPY ./CITATION.cf[f] /src/CITATION.cff
 
 WORKDIR /src
-CMD ["python", "run.py"]
+CMD ["spec", "run", "foobar", "--input-file", "/in/input.json"]

--- a/src/tool.yml
+++ b/src/tool.yml
@@ -2,6 +2,7 @@ tools:
   foobar:
     title: Foo Bar
     description: A dummy tool to exemplify the YAML file
+    command: "python run.py"
     parameters:
       foo_int: 
         type: integer


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Integrates the gotap runner and wires the tool to execute via `spec`.
> 
> - **Dockerfile:** Builds and installs the `spec` binary from `gotap`; cleans up build deps; updates default `CMD` to `spec run foobar --input-file /in/input.json`.
> - **tool.yml:** Adds `command: "python run.py"` for `foobar` so the runner knows how to invoke the tool.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1293a2ddedf40b49aeba76168717ae5349382fec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build process and tool execution configuration
  * Enhanced tool command definition in configuration settings

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->